### PR TITLE
adding noted on welcome page on how to enable webgpu support

### DIFF
--- a/src-v2/main.scss
+++ b/src-v2/main.scss
@@ -155,3 +155,12 @@ h3 {
   font-weight: bold;
   margin-bottom: 20px;
 }
+
+.webgpu-note {
+  background-color: #e0f7fa;
+  color: #006064;
+  padding: 15px;
+  border-radius: 5px;
+  text-align: center;
+  margin-bottom: 20px;
+}

--- a/src-v2/welcome.html
+++ b/src-v2/welcome.html
@@ -27,6 +27,11 @@
               Choose between <strong>local</strong> or <strong>server-based</strong> transcription and LLM
               processing to suit your needs
             </p>
+            <aside class="webgpu-note" role="note">
+              ⚙️ When using <strong>local</strong> transcription and LLM, please check and enable <strong>Unsafe WebGPU Support</strong> from <a href="chrome://flags/#enable-unsafe-webgpu">chrome://flags/#enable-unsafe-webgpu</a>
+              and <strong>use graphics acceleration when available</strong> from <a href="chrome://settings/system">chrome://settings/system</a>.
+              <strong>Please copy these links and paste them into your browser's address bar.</strong>
+            </aside>
           </li>
           <li>
             <strong>Real-time Audio Transcription</strong>


### PR DESCRIPTION
## Summary by Sourcery

Adds a note to the welcome page with instructions on how to enable WebGPU support for local transcription and LLM processing.

<img width="776" alt="Screenshot 2025-02-18 at 1 12 13 PM" src="https://github.com/user-attachments/assets/69d5d203-c8ea-4d72-bf48-9884c7d9c6a3" />

