### PR TITLE
Added a loading screen and a spinner 

### DIFF
--- a/src-v2/background.js
+++ b/src-v2/background.js
@@ -58,20 +58,19 @@ async function getOffscreenDocument() {
 
 // Function: loadExtension - Load the extension on the current tab.
 // Check if an offscreen document already exists and create a new one if it doesn't.
-// Inject the CSS and content script into the current tab.
-// Add the tab to the list of active tabs.
 async function loadExtension() {
-    // Get Offscreen document if present in the extension context
-    const offscreenDocument = await getOffscreenDocument();
-
-    // Only create a new offscreen document if one doesn't already exist
-    if (!offscreenDocument) {
-        // Create a new offscreen document
-        await chrome.offscreen.createDocument({
-            url: 'offscreen.html',
-            reasons: ['USER_MEDIA', 'WORKERS'],
-            justification: 'Recording from chrome.tabCapture API'
-        });
+    try {
+        const offscreenDocument = await getOffscreenDocument();
+        if (!offscreenDocument) {
+            await chrome.offscreen.createDocument({
+                url: 'offscreen.html',
+                reasons: ['USER_MEDIA', 'WORKERS'],
+                justification: 'Recording from chrome.tabCapture API'
+            });
+        }
+    } catch (error) {
+        console.error('Failed to load extension:', error);
+        throw error; // Re-throw to allow caller to handle
     }
 }
 
@@ -94,11 +93,22 @@ async function closeExtension() {
 }
 
 // Listener for the extension icon click
-// If the extension is already loaded for the host, unload it. Otherwise, load it.
 chrome.action.onClicked.addListener(async (tab) => {
-    await loadExtension();
-    chrome.action.setPopup({popup: 'popup.html'});
-    chrome.action.openPopup();
+    try {
+        // Initialize extension infrastructure
+        await loadExtension();
+        
+        // Set popup for future clicks (without forcing it open)
+        chrome.action.setPopup({popup: 'popup.html'});
+        
+        // Initialize recording system
+        await chrome.runtime.sendMessage({
+            target: 'offscreen', 
+            type: 'init'
+        });
+    } catch (error) {
+        console.error('Extension initialization error:', error);
+    }
 });
 
 

--- a/src-v2/offscreen.js
+++ b/src-v2/offscreen.js
@@ -50,6 +50,13 @@ let state = {
 };
 
 async function setState(newState, data = null) {
+    // Show/hide loading overlay based on state
+    if (newState === RecorderState.INITIALIZING || newState === RecorderState.LOADING) {
+        await sendMessage('show-loading');
+    } else if (newState === RecorderState.READY) {
+        await sendMessage('hide-loading');
+    }
+
     let newData = state.data
 
     if (data?.transcription) {

--- a/src-v2/popup.html
+++ b/src-v2/popup.html
@@ -6,11 +6,46 @@
     <title>FreeScribe</title>
     <link rel="stylesheet" href="main2.css"/>
     <link rel="stylesheet" href="fontawesome.min.css"/>
+    <style>
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.9);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    flex-direction: column;
+}
+
+.loading-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.loading-text {
+    font-size: 1.2rem;
+    color: #333;
+}
+</style>
     <script src="jquery-3.7.1.min.js"></script>
     <script src="toastr.min.js"></script>
     <script src="bootstrap.bundle.min.js"></script>
 </head>
 <body>
+<div id="loadingOverlay" class="loading-overlay">
+    <div class="loading-content">
+        <div class="spinner-border text-primary" style="width: 3rem; height: 3rem;" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+        <p class="loading-text">Loading models...</p>
+    </div>
+</div>
 <div class="popup-container">
     <div class="container fade-in">
         <h3>Select Audio Input</h3>

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -8,15 +8,13 @@ async function init() {
     loadingOverlay.style.display = 'flex';
     
     try {
-
+        let config = await loadConfig();
+        let logger = new Logger(config);
     } catch (error) {
         loadingOverlay.style.display = 'none';
         console.error("Initialization error:", error);
         throw error;
     }
-
-    let config = await loadConfig();
-    let logger = new Logger(config);
     let isRecording = false;
 
     let recordButton = document.getElementById("recordButton");

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -1,8 +1,6 @@
 import {loadConfig} from "../src/config.js";
 import {Logger} from "../src/logger.js";
 
-const LOADING_STORAGE_KEY = 'modelsInitialized';
-
 async function init() {
     const loadingOverlay = document.getElementById('loadingOverlay');
     

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -1,11 +1,24 @@
 import {loadConfig} from "../src/config.js";
 import {Logger} from "../src/logger.js";
 
+const LOADING_STORAGE_KEY = 'modelsInitialized';
+
 async function init() {
+    const loadingOverlay = document.getElementById('loadingOverlay');
+    
+    // Show loading UI immediately
+    loadingOverlay.style.display = 'flex';
+    
+    try {
+
+    } catch (error) {
+        loadingOverlay.style.display = 'none';
+        console.error("Initialization error:", error);
+        throw error;
+    }
+
     let config = await loadConfig();
-
     let logger = new Logger(config);
-
     let isRecording = false;
 
     let recordButton = document.getElementById("recordButton");
@@ -205,12 +218,15 @@ async function init() {
 
     const recordingStateHandler = {
         "initializing": (data) => {
+            document.getElementById('loadingOverlay').style.display = 'flex';
             recordButton.disabled = true;
         },
         "loading": (data) => {
+            document.getElementById('loadingOverlay').style.display = 'flex';
             recordButton.disabled = true;
         },
         "ready": (data) => {
+            document.getElementById('loadingOverlay').style.display = 'none';
             recordButton.disabled = false;
         },
         "recording": (data) => {
@@ -291,6 +307,15 @@ async function init() {
     }
 
     const messageHandler = {
+        "show-loading": () => {
+            document.getElementById('loadingOverlay').style.display = 'flex';
+        },
+        "hide-loading": () => {
+            document.getElementById('loadingOverlay').style.display = 'none';
+        },
+        "models-ready": () => {
+            document.getElementById('loadingOverlay').style.display = 'none';
+        },
         "recorder-state": (message) => {
             const {state, data} = message;
             console.log("Recorder state: ", state, data);

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -214,15 +214,15 @@ async function init() {
 
     const recordingStateHandler = {
         "initializing": (data) => {
-            document.getElementById('loadingOverlay').style.display = 'flex';
+            loadingOverlay.style.display = 'flex';
             recordButton.disabled = true;
         },
         "loading": (data) => {
-            document.getElementById('loadingOverlay').style.display = 'flex';
+            loadingOverlay.style.display = 'flex';
             recordButton.disabled = true;
         },
         "ready": (data) => {
-            document.getElementById('loadingOverlay').style.display = 'none';
+            loadingOverlay.style.display = 'none';
             recordButton.disabled = false;
         },
         "recording": (data) => {


### PR DESCRIPTION
- Added a loading screen and a spinner to let the user know that the model/record button is loading

## Summary by Sourcery

Introduce a user-facing loading screen in the popup during model and recorder setup, add robust error handling around offscreen document creation, and adjust the extension startup flow to initialize the recorder via messaging.

New Features:
- Add a full-screen loading overlay with spinner in the popup to indicate model and recorder initialization

Enhancements:
- Show or hide the loading overlay based on recorder state transitions and custom ‘show-loading’/‘hide-loading’ messages
- Wrap offscreen document creation in a try/catch with error logging and rethrow for better resilience
- Refactor the extension icon click handler to initialize the offscreen recorder by sending an ‘init’ message rather than directly opening the popup