### PR TITLE
Fix 42 warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@huggingface/transformers": "^3.0.2",
-        "bootstrap": "^5.3.3",
+        "bootstrap": "^5.3.6",
         "toastr": "^2.1.4",
         "ts-loader": "^9.5.1"
       },
@@ -2845,9 +2845,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@huggingface/transformers": "^3.0.2",
-    "bootstrap": "^5.3.3",
+    "bootstrap": "^5.3.6",
     "toastr": "^2.1.4",
     "ts-loader": "^9.5.1"
   },

--- a/src-v2/content.scss
+++ b/src-v2/content.scss
@@ -1,3 +1,7 @@
+@use "sass:math";
+@use "sass:color";
+@use "bootstrap/scss/bootstrap" as *;
+
 .free-scribe {
   * {
     all: unset;
@@ -5,8 +9,6 @@
     padding: 0;
     box-sizing: border-box;
   }
-
-  @import "../node_modules/bootstrap/scss/bootstrap";
 
   // Custom variables
   $primary-color: #007bff;

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,7 +1,7 @@
 @use "sass:math";
 @use "sass:color";
-@use "bootstrap/scss/bootstrap" as *;
-@use "toastr/build/toastr" as *;
+@use "~bootstrap/scss/bootstrap" as *;
+@use "~toastr" as *;
 
 // Custom variables
 $primary-color: #007bff;
@@ -84,7 +84,7 @@ button {
 
   &:hover {
     text-decoration: underline;
-    color: darken($secondary-color, 15%);
+    color: adjust-color($secondary-color, $lightness: -15%);
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -84,7 +84,7 @@ button {
 
   &:hover {
     text-decoration: underline;
-    color: adjust($secondary-color, $lightness: -15%);
+    color: color.scale($secondary-color, $lightness: -15%);
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,7 +1,7 @@
 @use "sass:math";
 @use "sass:color";
-@use "~bootstrap/scss/bootstrap" as *;
-@use "~toastr" as *;
+@use "bootstrap/scss/bootstrap" as *;
+@use "toastr" as *;
 
 // Custom variables
 $primary-color: #007bff;
@@ -84,7 +84,7 @@ button {
 
   &:hover {
     text-decoration: underline;
-    color: adjust-color($secondary-color, $lightness: -15%);
+    color: adjust($secondary-color, $lightness: -15%);
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,5 +1,7 @@
-@import "../node_modules/bootstrap/scss/bootstrap";
-@import "../node_modules/toastr/toastr";
+@use "sass:math";
+@use "sass:color";
+@use "bootstrap/scss/bootstrap" as *;
+@use "toastr/build/toastr" as *;
 
 // Custom variables
 $primary-color: #007bff;

--- a/webpack.v2.js
+++ b/webpack.v2.js
@@ -34,7 +34,20 @@ module.exports = (env) => {
                 },
                 {
                     test: /\.scss$/,
-                    use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
+                    use: [
+                        MiniCssExtractPlugin.loader,
+                        "css-loader",
+                        {
+                            loader: "sass-loader",
+                            options: {
+                                sassOptions: {
+                                    loadPaths: [path.resolve(__dirname, "node_modules")],
+                                    quietDeps: true,
+                                    style: "expanded"
+                                }
+                            }
+                        }
+                    ],
                 },
             ],
         },


### PR DESCRIPTION
Fixed the 42 warnings caused by deprecated functions such as **adjust()**, **adjust-color()**, **darken()**, and the **Sass module**. Resolved by using Aider architect.

## Summary by Sourcery

Fix deprecation warnings in the SCSS pipeline by migrating to the Dart Sass module system, updating loader configuration, and bumping the Bootstrap dependency.

Bug Fixes:
- Replace deprecated Sass functions and module imports (adjust(), adjust-color(), darken(), @import) with @use and sass:color/math equivalents

Enhancements:
- Configure sass-loader with explicit sassOptions (loadPaths, quietDeps, expanded style)
- Refactor SCSS files to use @use for bootstrap and toastr modules instead of @import

Build:
- Upgrade Bootstrap dependency from v5.3.3 to v5.3.6