### PR TITLE
Updated the README.md file

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -80,7 +80,19 @@ FreeScribe Copilot is customizable via the options page:
 To access the options page:
 
 1. Click the FreeScribe icon in the browser toolbar.
-2. Choose "Options" to configure your settings.
+2. Click on "Configuration" to configure your settings.
+
+### Setting up server-based Transcription
+
+1. Apply ths URL to the Transcription Server URL: https://localhost:2224/whisperaudio
+2. Get the Transcription Server API Key from the docker container logs: `speech-container`. 
+   ** make sure to get the latest API key
+
+### Setting uup server-based LLM
+
+1. Apply this URL to the LLM Server URL: https://localhost:3334/v1
+2. Get the LLM Server API Key from the docker container logs: `authentication-ollama`
+   ** make sure to get the latest API key
 
 ## License
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -84,15 +84,15 @@ To access the options page:
 
 ### Setting up server-based Transcription
 
-1. Apply ths URL to the Transcription Server URL: https://localhost:2224/whisperaudio
+1. Apply this URL to the Transcription Server URL: https://localhost:2224/whisperaudio
 2. Get the Transcription Server API Key from the docker container logs: `speech-container`. 
-   ** make sure to get the latest API key
+   **Make sure to get the latest API key
 
-### Setting uup server-based LLM
+### Setting up server-based LLM
 
 1. Apply this URL to the LLM Server URL: https://localhost:3334/v1
 2. Get the LLM Server API Key from the docker container logs: `authentication-ollama`
-   ** make sure to get the latest API key
+   **Make sure to get the latest API key
 
 ## License
 


### PR DESCRIPTION
- Added new information regarding the use of sever-based transcription and LLM.
- Moved the README.md file to the `.github\workflows`  directory

## Summary by Sourcery

Update README location and augment it with server-based transcription and LLM setup instructions.

Documentation:
- Rename instructions step to use the 'Configuration' label
- Add a section detailing setup for server-based transcription with endpoint URL and API key retrieval
- Add a section detailing setup for server-based LLM with endpoint URL and API key retrieval

Chores:
- Move README.md file into the .github/workflows directory