### PR TITLE
Fixed the bug when the realtime processing is enabled 

### DIFF
--- a/src-v2/background.js
+++ b/src-v2/background.js
@@ -102,6 +102,47 @@ chrome.action.onClicked.addListener(async (tab) => {
 });
 
 
+// Track tab changes to maintain recording state
+chrome.tabs.onActivated.addListener(async (activeInfo) => {
+    chrome.runtime.sendMessage({
+        target: 'offscreen', 
+        type: 'get-recording-state'
+    }, (response) => {
+        if (response) {
+            chrome.runtime.sendMessage({
+                target: 'content',
+                type: 'recorder-state',
+                state: response.isRecording ? 
+                    (response.isPaused ? 'paused' : 'recording') : 'ready',
+                data: {
+                    transcription: response.transcription,
+                    isPause: response.isPaused // Include pause state
+                }
+            });
+        }
+    });
+});
+
+chrome.tabs.onRemoved.addListener(async (tabId) => {
+    chrome.runtime.sendMessage({
+        target: 'offscreen', 
+        type: 'get-recording-state'
+    }, (response) => {
+        if (response) {
+            chrome.runtime.sendMessage({
+                target: 'content',
+                type: 'recorder-state',
+                state: response.isRecording ? 
+                    (response.isPaused ? 'paused' : 'recording') : 'ready',
+                data: {
+                    transcription: response.transcription,
+                    isPause: response.isPaused // Include pause state
+                }
+            });
+        }
+    });
+});
+
 // Listener for messages from other parts of the extension
 // Load the configuration and send it back to the sender
 // Open pages in a new tab

--- a/src-v2/background.js
+++ b/src-v2/background.js
@@ -116,7 +116,7 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
                     (response.isPaused ? 'paused' : 'recording') : 'ready',
                 data: {
                     transcription: response.transcription,
-                    isPause: response.isPaused // Include pause state
+                    isPause: response.isPaused
                 }
             });
         }
@@ -136,7 +136,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
                     (response.isPaused ? 'paused' : 'recording') : 'ready',
                 data: {
                     transcription: response.transcription,
-                    isPause: response.isPaused // Include pause state
+                    isPause: response.isPaused
                 }
             });
         }

--- a/src-v2/offscreen.js
+++ b/src-v2/offscreen.js
@@ -85,7 +85,13 @@ async function setState(newState, data = null) {
 }
 
 async function sendState() {
-    await sendMessage('recorder-state', state);
+    await sendMessage('recorder-state', {
+        ...state,
+        data: {
+            ...state.data,
+            isPause: isPause // Ensure pause state is included
+        }
+    });
 }
 
 async function init() {

--- a/src-v2/offscreen.js
+++ b/src-v2/offscreen.js
@@ -65,6 +65,11 @@ async function setState(newState, data = null) {
         newData.message = data.message;
     }
 
+    // Always maintain pause/resume state when recording
+    if (isRecording && (newState === RecorderState.RECORDING || newState === RecorderState.REALTIME_TRANSCRIBING)) {
+        newData.isPause = isPause;
+    }
+
     if (newState === RecorderState.INITIALIZING ||
         newState === RecorderState.LOADING ||
         newState === RecorderState.READY ||
@@ -371,10 +376,8 @@ async function pauseRecording() {
 
 async function resumeRecording() {
     if (!isPause) {
-        await setState(RecorderState.ERROR, {
-            message: "Called resumeRecording while not paused."
-        });
-        throw new Error('Called resumeRecording while not paused.');
+        // Just return instead of throwing error
+        return;
     }
 
     mediaRecorder.resume();

--- a/src-v2/offscreen.js
+++ b/src-v2/offscreen.js
@@ -380,13 +380,10 @@ async function resumeRecording() {
     mediaRecorder.resume();
     isPause = false;
 
-    if (config.REALTIME) {
-        await setState(RecorderState.REALTIME_TRANSCRIBING, {
-            transcription: speechToText
-        });
-    } else {
-        await setState(RecorderState.RECORDING);
-    }
+    // Always set state to RECORDING when resuming, even in realtime mode
+    await setState(RecorderState.RECORDING, {
+        transcription: speechToText
+    });
 }
 
 async function transcribeAudio() {
@@ -475,7 +472,8 @@ async function updateGUI(text) {
 
     if (config.REALTIME && isRecording) {
         await setState(RecorderState.REALTIME_TRANSCRIBING, {
-            transcription: speechToText
+            transcription: speechToText,
+            isPause: isPause // Include pause state in realtime updates
         });
     } else {
         await setState(RecorderState.TRANSCRIPTION_COMPLETE, {

--- a/src-v2/offscreen.js
+++ b/src-v2/offscreen.js
@@ -20,6 +20,7 @@ let apiCounter = 0;
 let speechToText = '';
 
 let audioDeviceId = null;
+let lastTranscription = '';
 
 const RecorderState = {
     INITIALIZING: 'initializing',
@@ -470,6 +471,7 @@ function hideLoader() {
 async function updateGUI(text) {
     speechToText += text;
     speechToText = speechToText.trim();
+    lastTranscription = speechToText; // Store last transcription
 
     if (config.REALTIME && isRecording) {
         await setState(RecorderState.REALTIME_TRANSCRIBING, {
@@ -702,6 +704,12 @@ function getAudioDeviceList() {
 chrome.runtime.onMessage.addListener(async (message) => {
     if (message.target === 'offscreen') {
         switch (message.type) {
+            case 'get-recording-state':
+                return Promise.resolve({
+                    isRecording: isRecording,
+                    isPaused: isPause,
+                    transcription: speechToText
+                });
             case 'start-recording':
                 startRecording();
                 break;

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -250,19 +250,22 @@ async function init() {
             notesElement.style.display = "none";
             copyNotesButton.style.display = "none";
             audioInputSelect.disabled = true;
-            // Always enable pause button when recording
             pauseButton.disabled = false;
+            // Always show stop button when recording (realtime or not)
             recordButton.style.display = "none";
+            stopButton.style.display = "inline";
             // Show pause/resume based on isPause state from data
             pauseButton.style.display = data?.isPause ? "none" : "inline";
             resumeButton.style.display = data?.isPause ? "inline" : "none";
-            stopButton.style.display = "inline";
             generateNotesButton.disabled = true;
         },
         "paused": (data) => {
+            // Ensure stop button remains visible when paused in realtime mode
+            recordButton.style.display = "none";
+            stopButton.style.display = "inline";
             pauseButton.style.display = "none";
             resumeButton.style.display = "inline";
-            resumeButton.disabled = false; // Ensure resume is enabled
+            resumeButton.disabled = false;
         },
         "recording-stopped": (data) => {
             audioInputSelect.disabled = false;

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -21,9 +21,12 @@ async function init() {
     if (recordingState.isRecording) {
         recordButton.style.display = "none";
         stopButton.style.display = "inline";
+        pauseButton.style.display = "inline"; // Always show pause when recording
+        pauseButton.disabled = false; // Ensure enabled
         if (recordingState.isPaused) {
             pauseButton.style.display = "none";
             resumeButton.style.display = "inline";
+            resumeButton.disabled = false; // Ensure enabled
         } else {
             pauseButton.style.display = "inline";
             resumeButton.style.display = "none";
@@ -247,17 +250,19 @@ async function init() {
             notesElement.style.display = "none";
             copyNotesButton.style.display = "none";
             audioInputSelect.disabled = true;
+            // Always enable pause button when recording
             pauseButton.disabled = false;
             recordButton.style.display = "none";
-            // Always show pause button when recording starts/resumes
-            pauseButton.style.display = "inline";
-            resumeButton.style.display = "none";
+            // Show pause/resume based on isPause state from data
+            pauseButton.style.display = data?.isPause ? "none" : "inline";
+            resumeButton.style.display = data?.isPause ? "inline" : "none";
             stopButton.style.display = "inline";
             generateNotesButton.disabled = true;
         },
         "paused": (data) => {
             pauseButton.style.display = "none";
             resumeButton.style.display = "inline";
+            resumeButton.disabled = false; // Ensure resume is enabled
         },
         "recording-stopped": (data) => {
             audioInputSelect.disabled = false;
@@ -279,12 +284,15 @@ async function init() {
             showLoader();
             showTranscription(data.transcription);
             generateNotesButton.disabled = true;
-            // Keep recording controls in sync with actual state
+            // Maintain recording controls state
             recordButton.style.display = "none";
             stopButton.style.display = "inline";
             // Use isPause from the message data to determine button state
             pauseButton.style.display = data.isPause ? "none" : "inline";
             resumeButton.style.display = data.isPause ? "inline" : "none";
+            // Always enable pause/resume buttons
+            pauseButton.disabled = false;
+            resumeButton.disabled = false;
         },
         "pre-processing-prompt": (data) => {
             hideLoader();

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -248,10 +248,10 @@ async function init() {
             copyNotesButton.style.display = "none";
             audioInputSelect.disabled = true;
             pauseButton.disabled = false;
-            isRecording = true;
             recordButton.style.display = "none";
-            resumeButton.style.display = "none";
+            // Always show pause button when recording starts/resumes
             pauseButton.style.display = "inline";
+            resumeButton.style.display = "none";
             stopButton.style.display = "inline";
             generateNotesButton.disabled = true;
         },
@@ -279,11 +279,12 @@ async function init() {
             showLoader();
             showTranscription(data.transcription);
             generateNotesButton.disabled = true;
-            // Ensure recording controls stay visible
+            // Keep recording controls in sync with actual state
             recordButton.style.display = "none";
             stopButton.style.display = "inline";
-            pauseButton.style.display = isPause ? "none" : "inline";
-            resumeButton.style.display = isPause ? "inline" : "none";
+            // Use isPause from the message data to determine button state
+            pauseButton.style.display = data.isPause ? "none" : "inline";
+            resumeButton.style.display = data.isPause ? "inline" : "none";
         },
         "pre-processing-prompt": (data) => {
             hideLoader();

--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -1,10 +1,37 @@
 import {loadConfig} from "../src/config.js";
 import {Logger} from "../src/logger.js";
 
+async function getRecordingState() {
+    return new Promise((resolve) => {
+        chrome.runtime.sendMessage({
+            target: 'offscreen', 
+            type: 'get-recording-state'
+        }, (response) => {
+            resolve(response || {isRecording: false, isPaused: false, transcription: ''});
+        });
+    });
+}
+
 async function init() {
     let config = await loadConfig();
-
     let logger = new Logger(config);
+
+    // Check current recording state
+    const recordingState = await getRecordingState();
+    if (recordingState.isRecording) {
+        recordButton.style.display = "none";
+        stopButton.style.display = "inline";
+        if (recordingState.isPaused) {
+            pauseButton.style.display = "none";
+            resumeButton.style.display = "inline";
+        } else {
+            pauseButton.style.display = "inline";
+            resumeButton.style.display = "none";
+        }
+        if (recordingState.transcription) {
+            showTranscription(recordingState.transcription);
+        }
+    }
 
     let isRecording = false;
 
@@ -252,6 +279,11 @@ async function init() {
             showLoader();
             showTranscription(data.transcription);
             generateNotesButton.disabled = true;
+            // Ensure recording controls stay visible
+            recordButton.style.display = "none";
+            stopButton.style.display = "inline";
+            pauseButton.style.display = isPause ? "none" : "inline";
+            resumeButton.style.display = isPause ? "inline" : "none";
         },
         "pre-processing-prompt": (data) => {
             hideLoader();


### PR DESCRIPTION
a new bug is discovered and it has something to do with the pause/resume button when the realtime processing enabled. Also fixed in the same branch [fix-bug/realtime-audio](https://github.com/ClinicianFOCUS/freescribe-copilot/tree/fix-bug/realtime-audio). All was done by aider.

what was fixed?
- the record/stop button's functionality is working well when switching tabs or opening/closing tabs
- the pause/resume button's functionality is working well when switching tabs or opening/closing tabs
- the record button remains at a "stop" state when the recording is paused then switching or opening/closing tabs

## Summary by Sourcery

Ensure recording controls and pause/resume behavior remain consistent in realtime processing across tab switches and closures by synchronizing state between popup, background, and offscreen contexts.

Bug Fixes:
- Fix pause/resume button and record/stop state retention when switching or closing tabs in realtime mode
- Prevent resumeRecording from throwing an error when called while not paused

Enhancements:
- Add getRecordingState handler in offscreen to fetch current recording, pause state and transcription
- Include isPause and transcription fields in recorder-state messages and popup initialization
- Add background listeners on tab activation and removal to resend recorder state to content scripts
- Update popup event handlers to always display and enable stop, pause, and resume buttons based on actual recording and pause states