### PR TITLE
Fix: Set default popup display to none

### DIFF
--- a/src-v2/popup.html
+++ b/src-v2/popup.html
@@ -14,7 +14,7 @@
     width: 100%;
     height: 100%;
     background-color: rgba(255, 255, 255, 0.9);
-    display: flex;
+    display: none;
     justify-content: center;
     align-items: center;
     z-index: 1000;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set the default CSS display of the popup to none instead of flex to hide it on load.