### PR TITLE
Fix Set user input content after error

### DIFF
--- a/src-v2/popup.js
+++ b/src-v2/popup.js
@@ -334,6 +334,7 @@ async function init() {
             recordButton.disabled = false;
             audioInputSelect.disabled = false;
             showErrorMessage(data.message)
+            userInput.textContent = data.transcription || "";
         }
     }
 


### PR DESCRIPTION
This makes it so the transcription stays in the transcription box even when note generation error. This makes it so we dont loose the transcribed text.

## Summary by Sourcery

Bug Fixes:
- Set user input text content to the last transcription or an empty string when showing an error message