### PR TITLE
fix(merge-conflict): Fixed left over symbols from merging before

### DIFF
--- a/src-v2/utils/UI/LoadingSpinner.js
+++ b/src-v2/utils/UI/LoadingSpinner.js
@@ -39,12 +39,12 @@ export class LoadingSpinner {
         }
     }
 
-+    static DEFAULT_LOADING_MESSAGE = 'Loading models...';
-+
-+    reset() {
-+        this.hide();
-+        if (this.loadingText) {
-+            this.loadingText.textContent = LoadingSpinner.DEFAULT_LOADING_MESSAGE;
-+        }
-+    }
+    static DEFAULT_LOADING_MESSAGE = 'Loading models...';
+
+    reset() {
+        this.hide();
+        if (this.loadingText) {
+            this.loadingText.textContent = LoadingSpinner.DEFAULT_LOADING_MESSAGE;
+        }
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Strip stray '+' symbols that were accidentally introduced during a previous merge in LoadingSpinner.js