### PR TITLE
refactor(note-save): Changed disk storage to in memory storage

### DIFF
--- a/src-v2/background.js
+++ b/src-v2/background.js
@@ -1,6 +1,4 @@
 import {loadConfig} from "../src/config";
-import {saveNotesHistory} from "../src/history";
-
 // Listener for when the extension is installed or updated and if installed,
 // open the welcome page in a new tab to show the user the new features and ask user permission to the microphone
 // Also, create a context menu item to start the extension
@@ -157,8 +155,16 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
 // Load the configuration and send it back to the sender
 // Open pages in a new tab
 // Forward messages to the offscreen document or content script based on the target
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+
+// In-memory storage for notes history
+let notesHistory = [];
+
+// Listen for messages from content scripts/popup/pages
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => { 
+    // Handle legacy action-based messages
+    // Handle target-based messages
     if (message.target === "background") {
+        console.log("Background.js received message:", message.action || message.type);
         if (message.type === "load-config") {
             // Load the configuration
             loadConfig().then((config) => {
@@ -167,10 +173,48 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             return true;
         } else if (message.type === "reload-extension") {
             closeExtension();
+            sendResponse({ success: true });
+            return true;
         } else if (message.type === 'save-notes') {
-            saveNotesHistory(message.data);
+            console.log("Saving notes:", message)
+            try {
+                let new_note = {
+                    time: new Date().toString(),
+                    note: message.data.note,
+                    transcription: message.data.transcription
+                };
+                
+                notesHistory = [new_note, ...notesHistory].slice(0, 20);
+                console.log("Notes history saved to background script memory:", notesHistory.length, "items");
+                sendResponse({ success: true, count: notesHistory.length });
+            } catch (error) {
+                console.error("Error saving notes history:", error);
+                sendResponse({ success: false, error: error.message });
+            }
+            return true;
+        } else if (message.type === 'getHistory') {
+            try {
+                console.log("Getting notes history from background script memory:", notesHistory.length, "items");
+                sendResponse({ history: notesHistory, success: true });
+            } catch (error) {
+                console.error("Error getting notes history:", error);
+                    sendResponse({ history: [], success: false, error: error.message });
+                }
+                return true;
+        } else if (message.type === 'clearHistory') {    
+            try {
+                notesHistory = [];
+                console.log("Notes history cleared from background script memory");
+                sendResponse({ success: true });
+            } catch (error) {
+                console.error("Error clearing notes history:", error);
+                sendResponse({ success: false, error: error.message });
+            }
+            return true;
         }
-    } else if (message.target === 'content' && message.type === 'recorder-state') {
+    }
+    // Handle recorder state updates
+    else if (message.target === 'content' && message.type === 'recorder-state') {
         let {data} = message;
 
         let text = '';
@@ -198,5 +242,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         chrome.action.setBadgeText({text});
         chrome.action.setBadgeBackgroundColor({color});
+        sendResponse({ success: true });
+        return true;
+    }
+    else {
+        console.log("Unhandled message:", message);
+        sendResponse({ success: false, error: "Message not handled" });
+        return true;
     }
 });

--- a/src-v2/background.js
+++ b/src-v2/background.js
@@ -198,8 +198,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 sendResponse({ history: notesHistory, success: true });
             } catch (error) {
                 console.error("Error getting notes history:", error);
-                    sendResponse({ history: [], success: false, error: error.message });
-                }
+                sendResponse({ history: [], success: false, error: error.message });
+            }
                 return true;
         } else if (message.type === 'clearHistory') {    
             try {

--- a/src-v2/content.js
+++ b/src-v2/content.js
@@ -1,6 +1,5 @@
 import {loadConfig} from "../src/config.js";
 import {Logger} from "../src/logger.js";
-import {saveNotesHistory} from "../src/history";
 
 async function init() {
     if (!document.getElementById("free-scribe-extension")) {
@@ -260,7 +259,6 @@ async function init() {
             notesElement.textContent = notes;
             notesElement.style.display = "block";
             copyNotesButton.style.display = "block";
-            saveNotesHistory(notes);
         }
 
         const hideNotes = () => {

--- a/src-v2/history.js
+++ b/src-v2/history.js
@@ -27,20 +27,47 @@ async function init(){
         let dateTime = new Date(historyAccordion.time).toLocaleString();
 
         html += `<div class="accordion-item">
-                <h2 class="accordion-header">
-                  <buttonn class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-                    data-bs-target="#historyAccordion${index}" aria-expanded="false" aria-controls="historyAccordion${index}"
-                  >${dateTime}</button>
-                </h2>
-                <div id="historyAccordion${index}" class="accordion-collapse collapse" data-bs-parent="#${accordionId}">
-                  <div class="accordion-body">
-                    <button data-copy-id="history-note-${index}" type="button" class="btn btn-sm btn-secondary copy-history-btn">
-                      <i class="fas fa-copy"></i> Copy Notes
-                    </button>
-                    <pre class="history-notes" id="history-note-${index}">${historyAccordion.note}</pre>
-                  </div>
+        <h2 class="accordion-header">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+            data-bs-target="#historyAccordion${index}" aria-expanded="false" aria-controls="historyAccordion${index}"
+          >${dateTime}</button>
+        </h2>
+        <div id="historyAccordion${index}" class="accordion-collapse collapse" data-bs-parent="#${accordionId}">
+          <div class="accordion-body">
+            ${historyAccordion.transcription ? `
+            <div class="mb-3">
+              <div class="row align-items-center mb-2">
+                <div class="col-6">
+                  <h6 class="mb-0 d-flex align-items-center"><i class="fas fa-microphone me-2"></i>Transcription</h6>
                 </div>
-              </div>`;
+                <div class="col-6 text-end">
+                  <button data-copy-id="history-transcription-${index}" type="button" class="btn btn-sm btn-secondary copy-history-btn d-flex align-items-center ms-auto">
+                    <i class="fas fa-copy me-2"></i>Copy Transcription
+                  </button>
+                </div>
+              </div>
+              <div class="transcription-container">
+                <pre class="history-transcription" id="history-transcription-${index}">${historyAccordion.transcription}</pre>
+              </div>
+            </div>
+            <hr>
+            ` : ''}
+            <div class="row align-items-center mb-2">
+              <div class="col-6">
+                <h6 class="mb-0 d-flex align-items-center"><i class="fas fa-file-alt me-2"></i>Generated Notes</h6>
+              </div>
+              <div class="col-6 text-end">
+                <button data-copy-id="history-note-${index}" type="button" class="btn btn-sm btn-secondary copy-history-btn d-flex align-items-center ms-auto">
+                  <i class="fas fa-copy me-2"></i>Copy Notes
+                </button>
+              </div>
+            </div>
+            <div class="notes-container">
+              <pre class="history-notes" id="history-note-${index}">${historyAccordion.note}</pre>
+            </div>
+          </div>
+        </div>
+      </div>`;
     }
 
     // Render the history accordion
@@ -51,17 +78,18 @@ async function init(){
 
     // Function to copy the history notes to the clipboard
     function copyHistory(event) {
-        let historyNotesId = event.currentTarget.getAttribute("data-copy-id");
+        let historyContentId = event.currentTarget.getAttribute("data-copy-id");
 
         navigator.clipboard
-            .writeText(document.getElementById(historyNotesId).textContent)
+            .writeText(document.getElementById(historyContentId).textContent)
             .then(() => {
-                toastr.info(`history notes copied to clipboard!`);
+                const contentType = historyContentId.includes('transcription') ? 'transcription' : 'notes';
+                toastr.info(`History ${contentType} copied to clipboard!`);
             })
             .catch((err) => {
-                toastr.info(`Failed to copy history notes. Please try again.`);
+                const contentType = historyContentId.includes('transcription') ? 'transcription' : 'notes';
+                toastr.info(`Failed to copy history ${contentType}. Please try again.`);
             });
-
     }
 
     // Add the click event to the copy history buttons

--- a/src-v2/offscreen.js
+++ b/src-v2/offscreen.js
@@ -158,7 +158,7 @@ async function loadConfigData() {
 
 const llmHandler = {
     "pre-processing": (text, extra) => generateNotes(extra.text, text),
-    "notes-processing": (text, extra) => postProcessData(text, extra.facts),
+    "notes-processing": (text, extra) => postProcessData(text, extra.facts, extra.text),
     "post-processing": (text, extra) => showGeneratedNotes(text),
 };
 
@@ -626,7 +626,7 @@ async function generateNotes(text, facts) {
     try {
         let notes = await llmApiCall(prompt);
 
-        await postProcessData(notes, facts);
+        await postProcessData(notes, facts, text);
     } catch (error) {
         await setState(RecorderState.ERROR, {
             message: "Unable to generate notes."
@@ -634,7 +634,7 @@ async function generateNotes(text, facts) {
     }
 }
 
-async function postProcessData(text, facts) {
+async function postProcessData(text, facts, originalTranscription) {
     logger.log("post processing notes");
     let notes = text;
     if (config.POST_PROCESSING) {
@@ -657,7 +657,7 @@ async function postProcessData(text, facts) {
                     message: postProcessingPrompt,
                     type: "post-processing",
                     extra: {
-                        text: text,
+                        text: originalTranscription,
                         facts: facts,
                     },
                 },
@@ -674,14 +674,14 @@ async function postProcessData(text, facts) {
         }
     }
 
-    await showGeneratedNotes(notes);
+    await showGeneratedNotes(notes, originalTranscription);
 }
 
-async function showGeneratedNotes(notes) {
+async function showGeneratedNotes(notes, transcription) {
     await setState(RecorderState.COMPLETE, {
         notes: notes
     });
-    sendMessage('save-notes', notes, 'background');
+    sendMessage('save-notes', { note: notes, transcription: transcription }, 'background');
 }
 
 function getAudioDeviceList() {

--- a/src/history.js
+++ b/src/history.js
@@ -1,30 +1,33 @@
-// Description: This file contains the functions to save and get notes history.
+// Description: This file contains the functions to save and get notes history in memory.
 //
-// Function saveNotesHistory: This function saves the notes history to the storage.
-export async function saveNotesHistory(note) {
-    // getting notes history
-    let notes_history = await getHistory();
+// In-memory storage for notes history
+let notesHistory = [];
 
-    // creating new note object
-    let new_note = {
-        time: new Date().toString(), note: note,
-    };
-
-    // saving only last 20 notes
-    let new_notes_history = [new_note, ...notes_history].slice(0, 20);
-
-    // saving notes history
-    chrome.storage.local.set({notes_history: new_notes_history}, function () {
-        console.log("notes history saved");
+// Function saveNotesHistory: This function saves the notes history via background script.
+export function saveNotesHistory(note, transcription = null) {
+    return new Promise((resolve) => {
+        chrome.runtime.sendMessage(
+            { type: 'save-notes', target: 'background', note: note, transcription: transcription },
+            (response) => resolve(response)
+        );
     });
 }
 
-// Function getHistory: This function gets the notes history from the storage.
+// Function getHistory: This function gets the notes history from background script.
 export async function getHistory() {
     return new Promise((resolve) => {
-        // getting notes history from storage and resolving it
-        chrome.storage.local.get(["notes_history"], function (result) {
-            resolve(result.notes_history || []);
+        chrome.runtime.sendMessage({ type: 'getHistory', target: 'background' }, (response) => {
+            console.log("Received history from background:", response);
+            resolve(response.history || []);
+        });
+    });
+}
+
+// Function clearHistory: This function clears the notes history in background script.
+export function clearHistory() {
+    return new Promise((resolve) => {
+        chrome.runtime.sendMessage({ type: 'clearHistory', target: 'background' }, (response) => {
+            resolve(response);
         });
     });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -703,7 +703,7 @@ document
 
             html += `<div class="accordion-item">
                 <h2 class="accordion-header">
-                  <buttonn class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                     data-bs-target="#historyAccordian${index}" aria-expanded="false" aria-controls="historyAccordian${index}"
                   >${dateTime}</button>
                 </h2>


### PR DESCRIPTION
## Summary by Sourcery

Migrate note history storage from disk to an in-memory queue in the background script accessed via messages, and extend the UI and processing pipeline to include and handle transcription data alongside notes

New Features:
- Store notes and transcriptions in an in-memory array managed by the background script with message-based API
- Display transcription alongside generated notes in the history accordion with its own copy button

Enhancements:
- Refactor storage utilities to send save/get/clear history requests to the background script instead of using chrome.storage.local
- Propagate original transcription through the offscreen post-processing and save it together with notes
- Enhance copy handler to distinguish between notes and transcription and show contextual toast messages