### PR TITLE
Increased token limit from 800 to 2048

### DIFF
--- a/src-v2/offscreen.js
+++ b/src-v2/offscreen.js
@@ -519,7 +519,7 @@ async function llmApiCall(prompt) {
                     },
                 ],
                 temperature: 0.7,
-                max_tokens: 800,
+                max_tokens: 2048,
             }),
         });
 

--- a/src-v2/worker.js
+++ b/src-v2/worker.js
@@ -252,7 +252,7 @@ async function generate(data) {
     const prompt = [{role: "user", content: message}];
 
     // Generate the response using the language model.
-    const result = await generator(prompt, {max_new_tokens: 128});
+    const result = await generator(prompt, {max_new_tokens: 2048});
 
     // Retrieve the generated text from the result.
     let outputText;

--- a/src/index.js
+++ b/src/index.js
@@ -496,7 +496,7 @@ async function llmApiCall(prompt) {
             }, body: JSON.stringify({
                 model: config.LLM_MODEL, messages: [{
                     role: "user", content: prompt,
-                },], temperature: 0.7, max_tokens: 800,
+                },], temperature: 0.7, max_tokens: 2048,
             }),
         });
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -210,7 +210,7 @@ async function generate(data) {
 
     const prompt = [{role: "user", content: message}];
 
-    const result = await generator(prompt, {max_new_tokens: 128});
+    const result = await generator(prompt, {max_new_tokens: 2048});
 
     let outputText;
     try {


### PR DESCRIPTION
## Summary by Sourcery

Increase the maximum output length for LLM calls to support longer generated responses.

Enhancements:
- Increase max_tokens in llmApiCall from 800 to 2048
- Increase max_new_tokens in generator calls from 128 to 2048