### PR TITLE
Fix 16 warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@huggingface/transformers": "^3.6.3",
-        "bootstrap": "^5.3.6",
+        "bootstrap": "^5.3.7",
         "toastr": "^2.1.4",
         "ts-loader": "^9.5.1"
       },
@@ -21,8 +21,8 @@
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
         "mini-css-extract-plugin": "^2.9.1",
-        "sass": "^1.80.3",
-        "sass-loader": "^16.0.2",
+        "sass": "^1.89.2",
+        "sass-loader": "^16.0.5",
         "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^6.0.1"
@@ -2083,6 +2083,7 @@
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
       "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -2789,9 +2790,9 @@
       "license": "MIT"
     },
     "node_modules/bootstrap": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
       "funding": [
         {
           "type": "github",
@@ -2804,15 +2805,6 @@
       ],
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -3195,6 +3187,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -3715,9 +3708,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
       "dev": true
     },
     "node_modules/import-local": {
@@ -4100,7 +4093,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -4650,14 +4644,13 @@
       ]
     },
     "node_modules/sass": {
-      "version": "1.80.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.3.tgz",
-      "integrity": "sha512-ptDWyVmDMVielpz/oWy3YP3nfs7LpJTHIJZboMVs8GEC9eUmtZTZhMHlTW98wY4aEorDfjN38+Wr/XjskFWcfA==",
+      "version": "1.89.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
+      "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "dev": true,
       "dependencies": {
-        "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
-        "immutable": "^4.0.0",
+        "immutable": "^5.0.2",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -4665,12 +4658,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/sass-loader": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.2.tgz",
-      "integrity": "sha512-Ll6iXZ1EYwYT19SqW4mSBb76vSSi8JgzElmzIerhEGgzB5hRjDQIWsPmuk1UrAXkR16KJHqVY0eH+5/uw9Tmfw==",
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
+      "integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
       "dev": true,
       "dependencies": {
         "neo-async": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@huggingface/transformers": "^3.6.3",
-    "bootstrap": "^5.3.6",
+    "bootstrap": "^5.3.7",
     "toastr": "^2.1.4",
     "ts-loader": "^9.5.1"
   },
@@ -39,8 +39,8 @@
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
     "mini-css-extract-plugin": "^2.9.1",
-    "sass": "^1.80.3",
-    "sass-loader": "^16.0.2",
+    "sass": "^1.89.2",
+    "sass-loader": "^16.0.5",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",
     "webpack-merge": "^6.0.1"

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,5 +1,5 @@
-@import "../node_modules/bootstrap/scss/bootstrap";
-@import "../node_modules/toastr/toastr";
+@use "bootstrap/scss/bootstrap" as *;
+@use "toastr" as *;
 
 // Custom variables
 $primary-color: #007bff;

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,5 +1,7 @@
 @use "bootstrap/scss/bootstrap" as *;
 @use "toastr" as *;
+@use "sass:color";
+
 
 // Custom variables
 $primary-color: #007bff;
@@ -82,7 +84,7 @@ button {
 
   &:hover {
     text-decoration: underline;
-    color: darken($secondary-color, 15%);
+    color: color.adjust($secondary-color, $lightness: -15%);
   }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate Sass code to the modern module API and bump related dependencies to eliminate deprecation warnings

Enhancements:
- Replace legacy @import statements with @use for bootstrap, toastr, and sass:color
- Swap deprecated darken() calls for color.adjust() to adjust secondary-color lightness
- Upgrade Bootstrap to v5.3.7, Sass to v1.89.2, and sass-loader to v16.0.5