### PR TITLE
Added a prompt template

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -201,6 +201,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 sendResponse({ history: [], success: false, error: error.message });
             }
                 return true;
+        } else if (message.type === 'update-template') {
+          // Forward to offscreen document
+          chrome.runtime.sendMessage({
+            target: 'offscreen',
+            type: 'update-template',
+            template: message.template
+          });
         } else if (message.type === 'clearHistory') {    
             try {
                 notesHistory = [];

--- a/src/background.js
+++ b/src/background.js
@@ -202,7 +202,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }
                 return true;
         } else if (message.type === 'update-template') {
-          // Forward to offscreen document
           chrome.runtime.sendMessage({
             target: 'offscreen',
             type: 'update-template',

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,17 @@
 // The configuration is saved in the Chrome storage API and can be accessed by the extension's background script.
 
 export const defaultConfig = {
+    // Prompt Templates
+    DEFAULT_LLM_CONTEXT_BEFORE: "AI, please transform the following conversation into a concise SOAP note. Do not assume any medical data, vital signs, or lab values. Base the note strictly on the information provided in the conversation. Ensure that the SOAP note is structured appropriately with Subjective, Objective, Assessment, and Plan sections. Strictly extract facts from the conversation. Here's the conversation:",
+    DEFAULT_LLM_CONTEXT_AFTER: "Remember, the Subjective section should reflect the patient's perspective and complaints as mentioned in the conversation. The Objective section should only include observable or measurable data from the conversation. The Assessment should be a summary of your understanding and potential diagnoses, considering the conversation's content. The Plan should outline the proposed management, strictly based on the dialogue provided. Do not add any information that did not occur and do not make assumptions. Strictly extract facts from the conversation.",
+    PROMPT_TEMPLATES: [
+        {
+            id: "default",
+            name: "Default Template",
+            prePrompt: "AI, please transform the following conversation into a concise SOAP note. Do not assume any medical data, vital signs, or lab values. Base the note strictly on the information provided in the conversation. Ensure that the SOAP note is structured appropriately with Subjective, Objective, Assessment, and Plan sections. Strictly extract facts from the conversation. Here's the conversation:",
+            postPrompt: "Remember, the Subjective section should reflect the patient's perspective and complaints as mentioned in the conversation. The Objective section should only include observable or measurable data from the conversation. The Assessment should be a summary of your understanding and potential diagnoses, considering the conversation's content. The Plan should outline the proposed management, strictly based on the dialogue provided. Do not add any information that did not occur and do not make assumptions. Strictly extract facts from the conversation."
+        }
+    ],
     // Transcription
     TRANSCRIPTION_LOCAL: true,
     TRANSCRIPTION_LOCAL_MODELS: ["onnx-community/whisper-tiny.en", "onnx-community/whisper-base",],

--- a/src/offscreen.js
+++ b/src/offscreen.js
@@ -3,6 +3,7 @@ import {SilenceDetector} from "./silenceDetector";
 import {sanitizeInput} from "./helpers";
 
 let config;
+let currentTemplate = null;
 let mediaRecorder;
 let audioChunks = [];
 let tabStream;
@@ -603,7 +604,11 @@ async function generateNotes(text, facts) {
         promptText = facts;
     }
 
-    const prompt = `${config.LLM_CONTEXT_BEFORE} ${promptText} ${config.LLM_CONTEXT_AFTER}`;
+    // Use current template if available, otherwise fall back to config
+    const prePrompt = currentTemplate?.prePrompt || config.LLM_CONTEXT_BEFORE;
+    const postPrompt = currentTemplate?.postPrompt || config.LLM_CONTEXT_AFTER;
+
+    const prompt = `${prePrompt} ${promptText} ${postPrompt}`;
 
     await setState(RecorderState.GENERATING_NOTES);
 
@@ -743,6 +748,9 @@ chrome.runtime.onMessage.addListener(async (message) => {
                 break;
             case 'set-audio-device':
                 audioDeviceId = message.data;
+                break;
+            case 'update-template':
+                currentTemplate = message.template;
                 break;
             case 'toggle-recording':
                 if (isRecording) {

--- a/src/offscreen.js
+++ b/src/offscreen.js
@@ -605,8 +605,12 @@ async function generateNotes(text, facts) {
     }
 
     // Use current template if available, otherwise fall back to config
-    const prePrompt = currentTemplate?.prePrompt || config.LLM_CONTEXT_BEFORE;
-    const postPrompt = currentTemplate?.postPrompt || config.LLM_CONTEXT_AFTER;
+    let prePrompt = currentTemplate?.prePrompt || config.LLM_CONTEXT_BEFORE;
+    let postPrompt = currentTemplate?.postPrompt || config.LLM_CONTEXT_AFTER;
+    
+    // Trim and sanitize template values
+    prePrompt = prePrompt.trim().replace(/\s+/g, ' ').replace(/[\x00-\x1F\x7F]/g, '');
+    postPrompt = postPrompt.trim().replace(/\s+/g, ' ').replace(/[\x00-\x1F\x7F]/g, '');
 
     const prompt = `${prePrompt} ${promptText} ${postPrompt}`;
 

--- a/src/options.html
+++ b/src/options.html
@@ -280,7 +280,7 @@
             <div class="d-flex align-items-stretch mb-2">
               <div class="me-2 flex-grow-1">
                 <select id="promptTemplates" class="form-select">
-                  <option value="default">Default Template</option>
+                  <option value="default">Default Prompt</option>
                   <option value="add">+ Add New Template</option>
                 </select>
               </div>

--- a/src/options.html
+++ b/src/options.html
@@ -274,6 +274,29 @@
             ></textarea>
           </div>
 
+          <!-- Prompt Templates Section -->
+          <div class="config-item">
+            <label for="promptTemplates">Prompt Templates:</label>
+            <div class="d-flex align-items-stretch mb-2">
+              <div class="me-2 flex-grow-1">
+                <select id="promptTemplates" class="form-select">
+                  <option value="default">Default Template</option>
+                  <option value="add">+ Add New Template</option>
+                </select>
+              </div>
+              <div class="me-2">
+                <button type="button" id="editTemplate" class="btn btn-secondary" disabled>
+                  <i class="fas fa-edit"></i>
+                </button>
+              </div>
+              <div>
+                <button type="button" id="deleteTemplate" class="btn btn-danger" disabled>
+                  <i class="fas fa-trash"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+
           <h3 class="mt-4">Real-time Processing Settings</h3>
           <div class="config-item form-check">
             <input
@@ -502,6 +525,36 @@
         </p>
       </div>
     </div>
+    <!-- Template Modal -->
+    <div class="modal fade" id="templateModal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="templateModalTitle">New Template</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="templateName" class="form-label">Template Name</label>
+              <input type="text" class="form-control" id="templateName" required>
+            </div>
+            <div class="mb-3">
+              <label for="templatePrePrompt" class="form-label">Pre Prompt</label>
+              <textarea class="form-control" id="templatePrePrompt" rows="5"></textarea>
+            </div>
+            <div class="mb-3">
+              <label for="templatePostPrompt" class="form-label">Post Prompt</label>
+              <textarea class="form-control" id="templatePostPrompt" rows="5"></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" id="saveTemplate" class="btn btn-primary">Save</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script type="module" src="options.js"></script>
   </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -64,15 +64,33 @@ function loadTemplates() {
 function updateTemplateDropdown() {
   const select = document.getElementById('promptTemplates');
   const currentValue = select.value;
-  
-  select.innerHTML = `
-    <option value="default">Default Prompt</option>
-    ${templates.filter(t => t.id !== "default").map(t => 
-      `<option value="${t.id}">${t.name}</option>`
-    ).join('')}
-    <option value="add">+ Add New Template</option>
-  `;
-  
+
+  // Clear existing options
+  select.innerHTML = '';
+
+  // Add default option
+  const defaultOption = document.createElement('option');
+  defaultOption.value = 'default';
+  defaultOption.textContent = 'Default Prompt';
+  select.appendChild(defaultOption);
+
+  // Add other templates safely
+  templates
+    .filter(t => t.id !== 'default')
+    .forEach(t => {
+      const option = document.createElement('option');
+      option.value = t.id;          
+      option.textContent = t.name;  
+      select.appendChild(option);
+    });
+
+  // Add "Add New Template" option
+  const addOption = document.createElement('option');
+  addOption.value = 'add';
+  addOption.textContent = '+ Add New Template';
+  select.appendChild(addOption);
+
+  // Restore previously selected value if it still exists
   if (currentValue && select.querySelector(`option[value="${currentValue}"]`)) {
     select.value = currentValue;
   }

--- a/src/options.js
+++ b/src/options.js
@@ -119,7 +119,9 @@ function saveTemplate() {
   
   if (currentTemplate) {
     const index = templates.findIndex(t => t.id === currentTemplate.id);
-    templates[index] = template;
+    if (index !== -1){
+        templates[index] = template;
+    }
   } else {
     templates.push(template);
   }

--- a/src/options.js
+++ b/src/options.js
@@ -4,6 +4,8 @@ import {isValidUrl} from "./helpers.js";
 // variables for the configuration settings
 let config;
 const customModelKey = "custom";
+let templates = [];
+let currentTemplate = null;
 
 // Function: getOptionsFromArray - Get the html options from an array of models
 // Map the array of models to an array of option elements and join them
@@ -51,6 +53,108 @@ function loadRemoteModelsOnSettingsChange() {
     if (isValidUrl(llmUrl)) {
         loadRemoteModels(llmUrl);
     }
+}
+
+// Template related functions
+function loadTemplates() {
+  templates = config.PROMPT_TEMPLATES || [];
+  updateTemplateDropdown();
+}
+
+function updateTemplateDropdown() {
+  const select = document.getElementById('promptTemplates');
+  const currentValue = select.value;
+  
+  select.innerHTML = `
+    <option value="default">Default Template</option>
+    ${templates.filter(t => t.id !== "default").map(t => 
+      `<option value="${t.id}">${t.name}</option>`
+    ).join('')}
+    <option value="add">+ Add New Template</option>
+  `;
+  
+  if (currentValue && select.querySelector(`option[value="${currentValue}"]`)) {
+    select.value = currentValue;
+  }
+}
+
+function showTemplateModal(template = null) {
+  const modal = new bootstrap.Modal(document.getElementById('templateModal'));
+  const title = document.getElementById('templateModalTitle');
+  const name = document.getElementById('templateName');
+  const prePrompt = document.getElementById('templatePrePrompt');
+  const postPrompt = document.getElementById('templatePostPrompt');
+  
+  if (template) {
+    title.textContent = 'Edit Template';
+    name.value = template.name;
+    prePrompt.value = template.prePrompt;
+    postPrompt.value = template.postPrompt;
+  } else {
+    title.textContent = 'New Template';
+    name.value = '';
+    prePrompt.value = config.DEFAULT_LLM_CONTEXT_BEFORE;
+    postPrompt.value = config.DEFAULT_LLM_CONTEXT_AFTER;
+  }
+  
+  modal.show();
+}
+
+function saveTemplate() {
+  const name = document.getElementById('templateName').value.trim();
+  const prePrompt = document.getElementById('templatePrePrompt').value.trim();
+  const postPrompt = document.getElementById('templatePostPrompt').value.trim();
+  
+  if (!name) {
+    alert('Please enter a template name');
+    return;
+  }
+  
+  const template = {
+    id: currentTemplate?.id || Date.now().toString(),
+    name,
+    prePrompt,
+    postPrompt
+  };
+  
+  if (currentTemplate) {
+    const index = templates.findIndex(t => t.id === currentTemplate.id);
+    templates[index] = template;
+  } else {
+    templates.push(template);
+  }
+  
+  config.PROMPT_TEMPLATES = templates;
+  saveConfig(config).then(() => {
+    loadTemplates();
+    applyTemplate(template.id);
+    bootstrap.Modal.getInstance(document.getElementById('templateModal')).hide();
+  });
+}
+
+function applyTemplate(templateId) {
+  if (templateId === 'default') {
+    document.getElementById('llmContextBefore').value = config.DEFAULT_LLM_CONTEXT_BEFORE;
+    document.getElementById('llmContextAfter').value = config.DEFAULT_LLM_CONTEXT_AFTER;
+    currentTemplate = templates.find(t => t.id === "default") || null;
+  } else if (templateId === 'add') {
+    currentTemplate = null;
+    showTemplateModal();
+    return;
+  } else {
+    const template = templates.find(t => t.id === templateId);
+    if (template) {
+      document.getElementById('llmContextBefore').value = template.prePrompt;
+      document.getElementById('llmContextAfter').value = template.postPrompt;
+      currentTemplate = template;
+    }
+  }
+  
+  // Update edit/delete buttons
+  const editBtn = document.getElementById('editTemplate');
+  const deleteBtn = document.getElementById('deleteTemplate');
+  editBtn.disabled = !currentTemplate || currentTemplate.id === "default";
+  deleteBtn.disabled = !currentTemplate || currentTemplate.id === "default";
 }
 
 // Function: showConfig - Show the configuration settings on the options page based on the saved configuration
@@ -317,6 +421,32 @@ document.addEventListener("DOMContentLoaded", async function (event) {
 
     // Load the configuration settings
     config = await loadConfig();
+    
+    // Initialize templates
+    loadTemplates();
+    applyTemplate('default');
+
+    // Template event listeners
+    document.getElementById('promptTemplates').addEventListener('change', (e) => {
+      applyTemplate(e.target.value);
+    });
+
+    document.getElementById('editTemplate').addEventListener('click', () => {
+      if (currentTemplate) showTemplateModal(currentTemplate);
+    });
+
+    document.getElementById('deleteTemplate').addEventListener('click', () => {
+      if (currentTemplate && currentTemplate.id !== "default" && confirm(`Delete template "${currentTemplate.name}"?`)) {
+        templates = templates.filter(t => t.id !== currentTemplate.id);
+        config.PROMPT_TEMPLATES = templates;
+        saveConfig(config).then(() => {
+          loadTemplates();
+          applyTemplate('default');
+        });
+      }
+    });
+
+    document.getElementById('saveTemplate').addEventListener('click', saveTemplate);
 
     // Show the configuration settings on the options page
     showConfig();

--- a/src/options.js
+++ b/src/options.js
@@ -66,7 +66,7 @@ function updateTemplateDropdown() {
   const currentValue = select.value;
   
   select.innerHTML = `
-    <option value="default">Default Template</option>
+    <option value="default">Default Prompt</option>
     ${templates.filter(t => t.id !== "default").map(t => 
       `<option value="${t.id}">${t.name}</option>`
     ).join('')}

--- a/src/popup.html
+++ b/src/popup.html
@@ -49,7 +49,6 @@
   width: 100% !important;
 }
 
-/* Add this to ensure consistent widths */
 .textarea-container,
 .config-item,
 button#generateNotesButton {

--- a/src/popup.html
+++ b/src/popup.html
@@ -125,7 +125,7 @@
         <div class="config-item mb-2 text-center">
           <!-- <label for="popupPromptTemplates" class="small">Prompts:</label> -->
           <select id="popupPromptTemplates" class="form-select form-select-sm w-75 mx-auto">
-            <option value="default">Default Template</option>
+            <option value="default">Default Prompt</option>
           </select>
         </div>
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -32,6 +32,27 @@
     font-size: 1.2rem;
     color: #333;
 }
+
+.small {
+  font-size: 0.875rem;
+}
+
+.form-select-sm {
+  height: calc(1.5em + 0.5rem + 2px);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0.2rem;
+}
+
+.w-75 {
+  width: 75% !important;
+}
+
+.mx-auto {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
 </style>
     <script src="jquery-3.7.1.min.js"></script>
     <script src="toastr.min.js"></script>
@@ -99,6 +120,13 @@
                     <span class="sr-only">Loading...</span>
                 </div>
             </div>
+        </div>
+
+        <div class="config-item mb-2 text-center">
+          <!-- <label for="popupPromptTemplates" class="small">Prompts:</label> -->
+          <select id="popupPromptTemplates" class="form-select form-select-sm w-75 mx-auto">
+            <option value="default">Default Template</option>
+          </select>
         </div>
 
         <button id="generateNotesButton" class="mb-3">

--- a/src/popup.html
+++ b/src/popup.html
@@ -45,13 +45,16 @@
   border-radius: 0.2rem;
 }
 
-.w-75 {
-  width: 75% !important;
+.w-100 {
+  width: 100% !important;
 }
 
-.mx-auto {
-  margin-left: auto !important;
-  margin-right: auto !important;
+/* Add this to ensure consistent widths */
+.textarea-container,
+.config-item,
+button#generateNotesButton {
+  width: 100%;
+  max-width: 100%;
 }
 </style>
     <script src="jquery-3.7.1.min.js"></script>
@@ -122,9 +125,8 @@
             </div>
         </div>
 
-        <div class="config-item mb-2 text-center">
-          <!-- <label for="popupPromptTemplates" class="small">Prompts:</label> -->
-          <select id="popupPromptTemplates" class="form-select form-select-sm w-75 mx-auto">
+        <div class="config-item mb-2">
+          <select id="popupPromptTemplates" class="form-select form-select-sm w-100">
             <option value="default">Default Prompt</option>
           </select>
         </div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -13,10 +13,54 @@ async function getRecordingState() {
     });
 }
 
+let config;
+let templates = [];
+let currentTemplate = null;
+
+function updateTemplateDropdown() {
+  const select = document.getElementById('popupPromptTemplates');
+  const currentValue = select.value;
+  
+  select.innerHTML = `
+    <option value="default">Default Template</option>
+    ${templates.filter(t => t.id !== "default").map(t => 
+      `<option value="${t.id}">${t.name}</option>`
+    ).join('')}
+  `;
+  
+  if (currentValue && select.querySelector(`option[value="${currentValue}"]`)) {
+    select.value = currentValue;
+  }
+}
+
+function applyTemplate(templateId) {
+  const template = templateId === 'default' 
+    ? { 
+        prePrompt: config.DEFAULT_LLM_CONTEXT_BEFORE,
+        postPrompt: config.DEFAULT_LLM_CONTEXT_AFTER 
+      }
+    : templates.find(t => t.id === templateId);
+
+  if (template) {
+    config.LLM_CONTEXT_BEFORE = template.prePrompt;
+    config.LLM_CONTEXT_AFTER = template.postPrompt;
+    currentTemplate = template;
+  }
+}
+
 async function init() {
-    let config = await loadConfig();
+    config = await loadConfig();
+    templates = config.PROMPT_TEMPLATES || [];
     let logger = new Logger(config);
     let loadingSpinner = new LoadingSpinner();
+
+    // Update template dropdown
+    updateTemplateDropdown();
+    
+    // Add event listener for template selection
+    document.getElementById('popupPromptTemplates').addEventListener('change', (e) => {
+      applyTemplate(e.target.value);
+    });
 
     // Check current recording state
     const recordingState = await getRecordingState();

--- a/src/popup.js
+++ b/src/popup.js
@@ -42,15 +42,19 @@ function applyTemplate(templateId) {
         prePrompt: config.DEFAULT_LLM_CONTEXT_BEFORE,
         postPrompt: config.DEFAULT_LLM_CONTEXT_AFTER 
       }
-    : templates.find(t => t.id === templateId);
+    : templates.find(t => t.id === templateId)
+   || { 
+        prePrompt: config.DEFAULT_LLM_CONTEXT_BEFORE,
+        postPrompt: config.DEFAULT_LLM_CONTEXT_AFTER 
+      }; 
 
-  if (template) {
+  //if (template) {
     chrome.runtime.sendMessage({
       target: 'offscreen',
       type: 'update-template',
       template: template
     });
-  }
+  //}
 }
 
 async function init() {

--- a/src/popup.js
+++ b/src/popup.js
@@ -15,7 +15,7 @@ async function getRecordingState() {
 
 let config;
 let templates = [];
-let currentTemplate = null;
+let currentTemplateId = 'default';
 
 function updateTemplateDropdown() {
   const select = document.getElementById('popupPromptTemplates');
@@ -34,6 +34,9 @@ function updateTemplateDropdown() {
 }
 
 function applyTemplate(templateId) {
+  currentTemplateId = templateId;
+  chrome.storage.local.set({ currentTemplateId });
+  
   const template = templateId === 'default' 
     ? { 
         prePrompt: config.DEFAULT_LLM_CONTEXT_BEFORE,
@@ -42,9 +45,11 @@ function applyTemplate(templateId) {
     : templates.find(t => t.id === templateId);
 
   if (template) {
-    config.LLM_CONTEXT_BEFORE = template.prePrompt;
-    config.LLM_CONTEXT_AFTER = template.postPrompt;
-    currentTemplate = template;
+    chrome.runtime.sendMessage({
+      target: 'offscreen',
+      type: 'update-template',
+      template: template
+    });
   }
 }
 
@@ -54,8 +59,16 @@ async function init() {
     let logger = new Logger(config);
     let loadingSpinner = new LoadingSpinner();
 
+    // Load saved template
+    const savedTemplate = await new Promise(resolve => {
+      chrome.storage.local.get(['currentTemplateId'], result => {
+        resolve(result.currentTemplateId || 'default');
+      });
+    });
+    
     // Update template dropdown
     updateTemplateDropdown();
+    applyTemplate(savedTemplate);
     
     // Add event listener for template selection
     document.getElementById('popupPromptTemplates').addEventListener('change', (e) => {

--- a/src/popup.js
+++ b/src/popup.js
@@ -20,14 +20,27 @@ let currentTemplateId = 'default';
 function updateTemplateDropdown() {
   const select = document.getElementById('popupPromptTemplates');
   const currentValue = select.value;
-  
-  select.innerHTML = `
-    <option value="default">Default Prompt</option>
-    ${templates.filter(t => t.id !== "default").map(t => 
-      `<option value="${t.id}">${t.name}</option>`
-    ).join('')}
-  `;
-  
+
+  // Clear existing options
+  select.innerHTML = '';
+
+  // Add default option
+  const defaultOption = document.createElement('option');
+  defaultOption.value = 'default';
+  defaultOption.textContent = 'Default Prompt';
+  select.appendChild(defaultOption);
+
+  // Add other templates safely
+  templates
+    .filter(t => t.id !== 'default')
+    .forEach(t => {
+      const option = document.createElement('option');
+      option.value = t.id;          
+      option.textContent = t.name;  
+      select.appendChild(option);
+    });
+
+  // Restore the previously selected value if still available
   if (currentValue && select.querySelector(`option[value="${currentValue}"]`)) {
     select.value = currentValue;
   }

--- a/src/popup.js
+++ b/src/popup.js
@@ -22,7 +22,7 @@ function updateTemplateDropdown() {
   const currentValue = select.value;
   
   select.innerHTML = `
-    <option value="default">Default Template</option>
+    <option value="default">Default Prompt</option>
     ${templates.filter(t => t.id !== "default").map(t => 
       `<option value="${t.id}">${t.name}</option>`
     ).join('')}


### PR DESCRIPTION
gives the user an option to choose between different prompts to get different results/output notes. 
- can edit/add/delete in the configuration settings
- dropdown in the main UI to select which prompt is going to be used.

## Summary by Sourcery

Implement prompt templates feature supporting configurable pre- and post-prompts, including UI for managing and selecting templates and integration into the note generation pipeline

New Features:
- Add prompt templates management with add/edit/delete functionality in options settings
- Add template selection dropdown in both options and popup interfaces
- Persist and apply selected template across sessions and communicate updates to the offscreen script

Enhancements:
- Define default prompt template in configuration and update offscreen note generation to use custom templates